### PR TITLE
Redirect authenticated users to main workspace

### DIFF
--- a/packages/frontend/core/src/desktop/pages/index/index.tsx
+++ b/packages/frontend/core/src/desktop/pages/index/index.tsx
@@ -1,10 +1,7 @@
 import { DefaultServerService } from '@affine/core/modules/cloud';
 import { DesktopApiService } from '@affine/core/modules/desktop-api';
 import { WorkspacesService } from '@affine/core/modules/workspace';
-import {
-  buildShowcaseWorkspace,
-  createFirstAppData,
-} from '@affine/core/utils/first-app-data';
+import { buildShowcaseWorkspace } from '@affine/core/utils/first-app-data';
 import { ServerFeature } from '@affine/graphql';
 import {
   useLiveData,
@@ -16,8 +13,8 @@ import {
   useCallback,
   useEffect,
   useLayoutEffect,
+  useMemo,
   useRef,
-  useState,
 } from 'react';
 import { useSearchParams } from 'react-router-dom';
 
@@ -25,7 +22,6 @@ import {
   RouteLogic,
   useNavigateHelper,
 } from '../../../components/hooks/use-navigate-helper';
-import { WorkspaceNavigator } from '../../../components/workspace-selector';
 import { AuthService } from '../../../modules/cloud';
 import { AppContainer } from '../../components/app-container';
 
@@ -37,16 +33,11 @@ import { AppContainer } from '../../components/app-container';
  */
 export const Component = ({
   defaultIndexRoute = 'all',
-  children,
   fallback,
 }: {
   defaultIndexRoute?: string;
-  children?: ReactNode;
   fallback?: ReactNode;
 }) => {
-  // navigating and creating may be slow, to avoid flickering, we show workspace fallback
-  const [navigating, setNavigating] = useState(true);
-  const [creating, setCreating] = useState(false);
   const authService = useService(AuthService);
   const defaultServerService = useService(DefaultServerService);
 
@@ -71,6 +62,13 @@ export const Component = ({
 
   const createOnceRef = useRef(false);
 
+  const hasAuthCookie = useMemo(() => {
+    return (
+      typeof document !== 'undefined' &&
+      document.cookie.includes('affine_session=')
+    );
+  }, []);
+
   const createCloudWorkspace = useCallback(() => {
     if (createOnceRef.current) return;
     createOnceRef.current = true;
@@ -87,46 +85,39 @@ export const Component = ({
   }, [defaultIndexRoute, jumpToPage, openPage, workspacesService]);
 
   useLayoutEffect(() => {
-    if (!navigating) {
-      return;
-    }
-
     if (listIsLoading) {
       return;
     }
 
-    if (!enableLocalWorkspace && !loggedIn) {
+    if (!enableLocalWorkspace && !loggedIn && !hasAuthCookie) {
       localStorage.removeItem('last_workspace_id');
       jumpToSignIn();
       return;
     }
 
-    // check is user logged in && has cloud workspace
     if (searchParams.get('initCloud') === 'true') {
       if (loggedIn) {
         if (list.every(w => w.flavour !== 'affine-cloud')) {
           createCloudWorkspace();
           return;
         }
-
-        // open first cloud workspace
         const openWorkspace =
           list.find(w => w.flavour === 'affine-cloud') ?? list[0];
         openPage(openWorkspace.id, defaultIndexRoute);
-      } else {
-        return;
       }
-    } else {
-      if (list.length === 0) {
-        setNavigating(false);
-        return;
-      }
-      // open last workspace
-      const lastId = localStorage.getItem('last_workspace_id');
-
-      const openWorkspace = list.find(w => w.id === lastId) ?? list[0];
-      openPage(openWorkspace.id, defaultIndexRoute, RouteLogic.REPLACE);
+      return;
     }
+
+    if (list.length === 0) {
+      if (!hasAuthCookie && !loggedIn) {
+        jumpToSignIn();
+      }
+      return;
+    }
+
+    const lastId = localStorage.getItem('last_workspace_id');
+    const openWorkspace = list.find(w => w.id === lastId) ?? list[0];
+    openPage(openWorkspace.id, defaultIndexRoute, RouteLogic.REPLACE);
   }, [
     enableLocalWorkspace,
     createCloudWorkspace,
@@ -136,8 +127,8 @@ export const Component = ({
     jumpToSignIn,
     listIsLoading,
     loggedIn,
-    navigating,
     defaultIndexRoute,
+    hasAuthCookie,
   ]);
 
   const desktopApi = useServiceOptional(DesktopApiService);
@@ -146,62 +137,5 @@ export const Component = ({
     desktopApi?.handler.ui.pingAppLayoutReady().catch(console.error);
   }, [desktopApi]);
 
-  useEffect(() => {
-    if (listIsLoading || list.length > 0 || !enableLocalWorkspace) {
-      return;
-    }
-
-    createFirstAppData(workspacesService)
-      .then(createdWorkspace => {
-        if (createdWorkspace) {
-          if (createdWorkspace.defaultPageId) {
-            jumpToPage(
-              createdWorkspace.meta.id,
-              createdWorkspace.defaultPageId
-            );
-          } else {
-            openPage(createdWorkspace.meta.id, 'all');
-          }
-        }
-      })
-      .catch(err => {
-        console.error('Failed to create first app data', err);
-      })
-      .finally(() => {
-        setCreating(false);
-      });
-  }, [
-    jumpToPage,
-    jumpToSignIn,
-    openPage,
-    workspacesService,
-    loggedIn,
-    listIsLoading,
-    list,
-    enableLocalWorkspace,
-  ]);
-
-  if (navigating || creating) {
-    return fallback ?? <AppContainer fallback />;
-  }
-
-  // TODO(@eyhn): We need a no workspace page
-  return (
-    children ?? (
-      <div
-        style={{
-          position: 'fixed',
-          left: 'calc(50% - 150px)',
-          top: '50%',
-        }}
-      >
-        <WorkspaceNavigator
-          open={true}
-          menuContentOptions={{
-            forceMount: true,
-          }}
-        />
-      </div>
-    )
-  );
+  return fallback ?? <AppContainer fallback />;
 };

--- a/packages/frontend/core/src/desktop/pages/sign-in/index.tsx
+++ b/packages/frontend/core/src/desktop/pages/sign-in/index.tsx
@@ -1,0 +1,1 @@
+export { Component } from '../auth/sign-in';


### PR DESCRIPTION
## Summary
- redirect unauthenticated users to `/sign-in` instead of creating demo workspace
- wait for cookie-authenticated sessions and open last workspace when available
- add `/sign-in` page reusing existing login popup component

## Testing
- `npx --yes yarn eslint packages/frontend/core/src/desktop/pages/index/index.tsx packages/frontend/core/src/desktop/pages/sign-in/index.tsx && echo 'LINT-PASSED'`
- `yarn vitest run packages/frontend/core/src/desktop/pages/index/index.tsx packages/frontend/core/src/desktop/pages/sign-in/index.tsx` *(fails: No test files found, exiting with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68b5d165df5c832c930c2fd942da8beb